### PR TITLE
implement adjoint

### DIFF
--- a/src/KeldyshContraction.jl
+++ b/src/KeldyshContraction.jl
@@ -19,6 +19,7 @@ include("hashing.jl")
 
 # Propagators
 include("propagator.jl")
+include("symbolic_utils.jl")
 include("wick_contractions.jl")
 include("self_energy.jl")
 

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -154,6 +154,13 @@ for ff in [:regularisations, :contours, :isbulk, :positions, :acts_on, :propagat
     end
 end
 
+# function Base.adjoint(q::Average)
+#     T = propagator_type(q)
+#     if is_advanced(T)
+#         return SymbolicUtils.BasicSymbolic{Propagator{Retarded}}(q)
+
+# end
+
 ##########################################
 #       dressed green's function
 ##########################################

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -154,13 +154,16 @@ for ff in [:regularisations, :contours, :isbulk, :positions, :acts_on, :propagat
     end
 end
 
-# function Base.adjoint(q::Average)
-#     T = propagator_type(q)
-#     if is_advanced(T)
-#         return SymbolicUtils.BasicSymbolic{Propagator{Retarded}}(q)
-
-# end
-
+function Base.conj(q::Average)
+    T = propagator_type(q)
+    if is_keldysh(T)
+        return -1 * q
+    else # retarded || advanced
+        x, y = fields(q)
+        return make_propagator(y(position(x))', x(position(y))')
+    end
+end
+Base.adjoint(q::Average) = conj(q)
 ##########################################
 #       dressed green's function
 ##########################################

--- a/src/symbolic_utils.jl
+++ b/src/symbolic_utils.jl
@@ -1,5 +1,3 @@
-_adjoint(s::SymbolicUtils.Symbolic{<:Number}) = _conj(s)
-
 function _conj(v::T) where {T<:SymbolicUtils.Symbolic}
     if SymbolicUtils.iscall(v)
         f = SymbolicUtils.operation(v)
@@ -11,6 +9,7 @@ function _conj(v::T) where {T<:SymbolicUtils.Symbolic}
 end
 _conj(q::Average) = conj(q)
 _conj(x::Number) = Base.conj(x)
+# _adjoint(s::SymbolicUtils.Symbolic{<:Number}) = _conj(s)
 
 function make_real(v::T) where {T<:SymbolicUtils.Symbolic}
     if SymbolicUtils.iscall(v)

--- a/src/symbolic_utils.jl
+++ b/src/symbolic_utils.jl
@@ -1,0 +1,43 @@
+_adjoint(s::SymbolicUtils.Symbolic{<:Number}) = _conj(s)
+
+function _conj(v::T) where {T<:SymbolicUtils.Symbolic}
+    if SymbolicUtils.iscall(v)
+        f = SymbolicUtils.operation(v)
+        args = map(_conj, SymbolicUtils.arguments(v))
+        return SymbolicUtils.maketerm(T, f, args, TermInterface.metadata(v))
+    else
+        return conj(v)
+    end
+end
+_conj(q::Average) = conj(q)
+_conj(x::Number) = Base.conj(x)
+
+function make_real(v::T) where {T<:SymbolicUtils.Symbolic}
+    if SymbolicUtils.iscall(v)
+        f = SymbolicUtils.operation(v)
+        args = map(make_real, SymbolicUtils.arguments(v))
+        return SymbolicUtils.maketerm(T, f, args, TermInterface.metadata(v))
+    else
+        return SymbolicUtils._isreal(v) ? real(v) : v
+    end
+end
+make_real(x::Average) = x
+make_real(x::Number) = SymbolicUtils._isreal(x) ? real(x) : x
+# Base.isreal(::SymbolicUtils.BasicSymbolic{Real}) = true
+# Base.isreal(::SymbolicUtils.BasicSymbolic{Number}) = false
+
+# let SymbolicUtils = SymbolicUtils, Rewriters = SymbolicUtils.Rewriters
+#     # using SymbolicUtils: @rule
+#     r1 = SymbolicUtils.@rule conj(*(~x, ~y)) => conj(~x) * conj(~y)
+#     r1′ = SymbolicUtils.@rule conj(*(~~x, ~~y)) => conj(~~x) * conj(~~y)
+#     r2 = SymbolicUtils.@rule conj(+(~x, ~y)) => conj(~x) + conj(~y)
+#     r2′ = SymbolicUtils.@rule conj(+(~~x, ~~y)) => conj(~~x) + conj(~~y)
+#     rule = Rewriters.PassThrough(
+#         Rewriters.Fixpoint(Rewriters.Postwalk(Rewriters.Chain([r2, r1, r2′, r1′])))
+#     )
+
+#     global _conj
+
+#     _conj(x) = SymbolicUtils.simplify(conj(x); rewriter=rule, expand=true)
+
+# end

--- a/src/wick_contractions.jl
+++ b/src/wick_contractions.jl
@@ -141,7 +141,7 @@ The function returns a new expression of propagators of type `SymbolicUtils.Symb
 function wick_contraction(a::QAdd; regularise=true)
     wick_contractions = wick_contraction.(SymbolicUtils.arguments(a); regularise)
     wick_contractions = sum(wick_contractions)
-    return SymbolicUtils.expand(wick_contractions)
+    return make_real(SymbolicUtils.expand(wick_contractions))
 end
 function wick_contraction(a::QMul; regularise=true)
     @assert is_conserved(a)

--- a/test/propagator.jl
+++ b/test/propagator.jl
@@ -1,10 +1,10 @@
 using KeldyshContraction, Test
 using KeldyshContraction: In, Out, Classical, Quantum, Plus, Minus
-using KeldyshContraction: propagator, position, contour
+using KeldyshContraction: propagator, position, contour, make_propagator
 
 @qfields ϕᶜ::Destroy(Classical) ϕᴾ::Destroy(Quantum)
 
-@test_skip - propagator(ϕᶜ, ϕᶜ') # this errors
+@test_skip -propagator(ϕᶜ, ϕᶜ') # this errors
 
 @testset "propagator checks" begin
     @test_throws AssertionError propagator(ϕᶜ, ϕᶜ) # annihilation creation
@@ -29,14 +29,23 @@ end
 @testset "sort" begin
     p1 = propagator(ϕᴾ, ϕᶜ'(In))
     p2 = propagator(ϕᴾ, ϕᶜ')
-    @test isequal(sort!([p1, p2], by=KeldyshContraction.acts_on), [p2, p1])
+    @test isequal(sort!([p1, p2]; by=KeldyshContraction.acts_on), [p2, p1])
+end
+
+@testset "adjoint" begin
+    p1 = make_propagator(ϕᴾ, ϕᶜ'(In))
+    p2 = make_propagator(ϕᶜ, ϕᴾ'(In))
+    @test isequal(p1', p2) # (G^R)† = G^A
+
+    p = make_propagator(ϕᶜ, ϕᶜ'(In))
+    @test isequal(p', -1 * p) # (G^K)† = -G^K
 end
 
 @testset "math" begin
     p1 = propagator(ϕᶜ, ϕᶜ'(In))
     p2 = propagator(ϕᶜ, ϕᶜ'(In))
-    @test isequal(p1 + p2, 2*p1)
-    @test isequal(p1*p2, p1^2)
+    @test isequal(p1 + p2, 2 * p1)
+    @test isequal(p1 * p2, p1^2)
 end
 
 @testset "regularisation" begin
@@ -51,7 +60,7 @@ end
     p1 = propagator(ϕᶜ, ϕᶜ'(In))
     p2 = propagator(ϕᴾ, ϕᶜ'(In))
 
-    @test_throws AssertionError KeldyshContraction.regular(-im*p1*p2)
+    @test_throws AssertionError KeldyshContraction.regular(-im * p1 * p2)
 end
 
 @testset "propagator type" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,10 @@ end
     include("QField.jl")
 end
 
+@testset "symbolic utils" begin
+    include("symbolic_utils.jl")
+end
+
 @testset "propagator" begin
     include("propagator.jl")
 end

--- a/test/symbolic_utils.jl
+++ b/test/symbolic_utils.jl
@@ -1,0 +1,15 @@
+using KeldyshContraction, Test
+using KeldyshContraction: make_real, _conj
+using SymbolicUtils
+
+@syms x::Real y::Real z
+
+@test SymbolicUtils._isreal(x)
+
+expr = (1+1*im)*z + (1-1*im)*z
+@test isequal(make_real(expr), 2*z)
+@test isequal(_conj(make_real(expr)), 2*conj(z))
+
+expr = (1+1*im)*x + (1-1*im)*x
+@test isequal(make_real(expr), 2*x)
+@test isequal(_conj(make_real(expr)), 2*x)

--- a/test/two_boson_loss.jl
+++ b/test/two_boson_loss.jl
@@ -68,9 +68,12 @@ end
         @test advanced_test
         @test retarded_test
         @test keldysh_test
-        # ^ pretty sure Gerbino thesis is wrong and switshes retarded and advanced
-        # and we compute the correct
-        # In his paper it is correct https://arxiv.org/pdf/2406.20028 :)
+        # ^ pretty sure Gerbino et al ttps://arxiv.org/pdf/2406.20028
+        # is wrong and switshes retarded and advanced
+        # and we compute the correct with a overall minus sign
+
+        @test isequal(KeldyshContraction._conj(Σ.advanced), Σ.retarded)
+        @test isequal(KeldyshContraction._conj(Σ.keldysh), -1*Σ.keldysh)
     end
 
     @testset "Keldysh GF is enough" begin


### PR DESCRIPTION
## Checklist

Thank you for contributing to `KeldyshContour.jl`! Please make sure you have finished the following tasks before finishing the PR.

<!-- - [ ] Any code changes were done in a way that does not break public API. -->
- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.
<!-- - [ ] (If necessary) the `CHANGELOG.md` should be updated (regarding to the code changes) and built by running: `make changelog`. -->

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Adds the feature to take the adjoint of the propagators

![Image](https://github.com/user-attachments/assets/c1353cf9-d8c7-4a29-a179-839683995453)

In addition, we add some self-energy tests using the above feature

![Image](https://github.com/user-attachments/assets/e2fdb628-d3da-4b7d-819c-5815f6f541e6)

## Related issues or PRs

resolves #13 

## Additional context

```julia
using SymbolicUtils,  SymbolicUtils.Rewriters
using TermInterface
using BenchmarkTools

function _conj(v::T) where {T<:SymbolicUtils.Symbolic}
    if SymbolicUtils.iscall(v)
        f = SymbolicUtils.operation(v)
        args = map(_conj, SymbolicUtils.arguments(v))
        return SymbolicUtils.maketerm(T, f, args, TermInterface.metadata(v))
    else
        return conj(v)
    end
end
_conj(x::Number) = Base.conj(x)

@syms x::Real y::Real z

expr1 = im * z
expr2 = -  im * x
expr = expr1 + expr2
expr_conj = conj(expr)
_conj(expr)

r1 = @acrule conj(*(~x, ~y)) => conj(~x) * conj(~y)
r1′ = @acrule conj(*(~~x, ~~y)) => conj(~~x) * conj(~~y)
r2 = @acrule conj(+(~x, ~y)) => conj(~x) + conj(~y)
r2′ = @acrule conj(+(~~x, ~~y)) => conj(~~x) + conj(~~y)
rule = PassThrough(Fixpoint(Postwalk(Chain([r2, r1, r2′, r1′]))))
ff(x) = simplify(conj(x); rewriter=rule, expand=true)

julia> @btime ff($expr)
228.001 μs (1934 allocations: 82.31 KiB)
(0 + 1im)*x + (0 - 1im)*conj(z)

julia> @btime _conj($expr)
17.860 μs (193 allocations: 7.78 KiB)
(0 + 1im)*x + (0 - 1im)*conj(z)

```
