### PR TITLE
docs: add two_body_scattering benchmark

### DIFF
--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -4,9 +4,11 @@ using KeldyshContraction: Classical, Quantum, Plus, Minus
 
 const SUITE = BenchmarkGroup()
 
-include("first_order_two_body_loss.jl")
+include("two_body_loss.jl")
+include("two_body_scattering.jl")
 
 benchmark_two_body_loss!(SUITE)
+benchmark_two_body_scattering!(SUITE)
 
 BenchmarkTools.tune!(SUITE)
 results = BenchmarkTools.run(SUITE; verbose=true)

--- a/benchmarks/two_body_loss.jl
+++ b/benchmarks/two_body_loss.jl
@@ -11,13 +11,13 @@ function benchmark_two_body_loss!(SUITE)
     Σ = SelfEnergy(GF)
 
     simplify = false
-    SUITE["two body loss"]["Green's function"] = @benchmarkable wick_contraction(
+    SUITE["Two body loss"]["Green's function"] = @benchmarkable wick_contraction(
         $L_int; simplify=($(simplify))
     ) seconds = 10
-    SUITE["two body loss"]["self energy"] = @benchmarkable SelfEnergy($GF) seconds = 10
+    SUITE["Two body loss"]["Self-energy"] = @benchmarkable SelfEnergy($GF) seconds = 10
 
     order = 2
-    SUITE["two body loss"]["Green's function second_order"] = @benchmarkable wick_contraction(
+    SUITE["Two body loss"]["Green's function second order"] = @benchmarkable wick_contraction(
         $L_int; order=($order), simplify=($(simplify))
     ) seconds = 50
     return nothing

--- a/benchmarks/two_body_scattering.jl
+++ b/benchmarks/two_body_scattering.jl
@@ -1,0 +1,20 @@
+function benchmark_two_body_scattering!(SUITE)
+    @qfields c::Destroy(Classical) q::Destroy(Quantum)
+    elasctic2boson = 0.5 * (c^2 + q^2) * c' * q' + 0.5 * c * q * ((c')^2 + (q')^2)
+    L_int = InteractionLagrangian(elasctic2boson)
+
+    GF = wick_contraction(L_int)
+    # Σ = SelfEnergy(GF)
+
+    simplify = false
+    SUITE["Two body loss"]["Green's function"] = @benchmarkable wick_contraction(
+        $L_int; simplify=($(simplify))
+    ) seconds = 10
+    # SUITE["Two body loss"]["Self-energy"] = @benchmarkable SelfEnergy($GF) seconds = 10
+
+    order = 2
+    SUITE["Two body loss"]["Green's function second order"] = @benchmarkable wick_contraction(
+        $L_int; order=($order), simplify=($(simplify))
+    ) seconds = 50
+    return nothing
+end

--- a/benchmarks/two_body_scattering.jl
+++ b/benchmarks/two_body_scattering.jl
@@ -7,13 +7,13 @@ function benchmark_two_body_scattering!(SUITE)
     # Σ = SelfEnergy(GF)
 
     simplify = false
-    SUITE["Two body loss"]["Green's function"] = @benchmarkable wick_contraction(
+    SUITE["Two body scattering"]["Green's function"] = @benchmarkable wick_contraction(
         $L_int; simplify=($(simplify))
     ) seconds = 10
     # SUITE["Two body loss"]["Self-energy"] = @benchmarkable SelfEnergy($GF) seconds = 10
 
     order = 2
-    SUITE["Two body loss"]["Green's function second order"] = @benchmarkable wick_contraction(
+    SUITE["Two body scattering"]["Green's function second order"] = @benchmarkable wick_contraction(
         $L_int; order=($order), simplify=($(simplify))
     ) seconds = 50
     return nothing


### PR DESCRIPTION
## Checklist

Thank you for contributing to `KeldyshContraction.jl`! Please make sure you have finished the following tasks before finishing the PR.

- [x] Appropriate tests were added and tested locally by running: `make test`.
- [x] Any code changes should be `julia` formatted by running: `make format`.
- [x] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

add two body scatting to benchmarks