### PR TITLE
refactor: move reguralise pre-allocating step

### DIFF
--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -133,8 +133,12 @@ fields(p::Average) = SymbolicUtils.arguments(p)
 function regularisations(p::Average)
     return regularisation.(fields(p))
 end
+function regularisations(qs::Vector{QSym})
+    return regularisation.(qs)
+end
 contours(p::Average) = contour.(fields(p))
 isbulk(p::Average) = all(isbulk.(fields(p)))
+isbulk(qs::Vector{QSym}) = all(isbulk.(qs))
 function positions(p::Average)
     return position.(fields(p))
 end

--- a/src/reguralisation.jl
+++ b/src/reguralisation.jl
@@ -26,6 +26,20 @@ function regular(p::Average)
         return true
     end
 end
+function regular(qs::Vector{QSym})
+    _isbulk = isbulk(qs)
+    _reg = regularisations(qs)
+    T = propagator_type(propagator(qs...))
+    if !_isbulk || subtraction(_reg) == 0
+        return true
+    elseif subtraction(_reg) < 0 && T == Retarded
+        return false
+    elseif subtraction(_reg) > 0 && T == Advanced
+        return false
+    else
+        return true
+    end
+end
 regular(p) = true
 regular(x::CSym) = regular(get_propagator(x))
 

--- a/test/two_boson_loss.jl
+++ b/test/two_boson_loss.jl
@@ -24,7 +24,7 @@ end
         @test is_conserved(expr)
         @test is_physical(expr)
 
-        wick_contractions = wick_contraction(expr.arguments[1].args_nc)
+        wick_contractions = wick_contraction(expr.arguments[1].args_nc; regularise=false)
         @test length(wick_contractions) == 4
 
         propagators = make_propagators(wick_contractions)


### PR DESCRIPTION
## Checklist

Thank you for contributing to `KeldyshContraction.jl`! Please make sure you have finished the following tasks before finishing the PR.

- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

Move tadpole reguralisation filtering where all the filtering happens

