### PR TITLE
ci: enforce supported type-stability contract

### DIFF
--- a/.github/check_coverage.jl
+++ b/.github/check_coverage.jl
@@ -1,0 +1,45 @@
+function source_relative_path(path::AbstractString)
+    normalized = normpath(path)
+    root = normpath(pwd())
+    if startswith(normalized, root)
+        return relpath(normalized, root)
+    end
+    marker = string(Base.Filesystem.path_separator, "src", Base.Filesystem.path_separator)
+    index = findfirst(marker, normalized)
+    isnothing(index) && return normalized
+    return normalized[(first(index) + 1):end]
+end
+
+function uncovered_source_lines(path::AbstractString)
+    uncovered = Dict{String,Vector{Int}}()
+    source = nothing
+
+    for line in eachline(path)
+        if startswith(line, "SF:")
+            source = source_relative_path(line[4:end])
+        elseif startswith(line, "DA:") && source !== nothing && startswith(source, "src/")
+            fields = split(line[4:end], ',')
+            line_number = parse(Int, fields[1])
+            count = parse(Int, fields[2])
+            iszero(count) || continue
+            push!(get!(uncovered, source, Int[]), line_number)
+        end
+    end
+
+    return uncovered
+end
+
+coverage_file = length(ARGS) == 1 ? only(ARGS) : "lcov.info"
+uncovered = uncovered_source_lines(coverage_file)
+
+if isempty(uncovered)
+    println("Source line coverage: 100%")
+    exit(0)
+end
+
+println(stderr, "Source line coverage is below 100%. Uncovered package-owned lines:")
+for source in sort!(collect(keys(uncovered)))
+    lines = sort!(unique(uncovered[source]))
+    println(stderr, "  ", source, ": ", join(lines, ", "))
+end
+exit(1)

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - '.github/workflows/Tests.yml'
+      - '.github/check_coverage.jl'
       - 'codecov.yml'
       - 'src/**'
       - 'ext/**'
@@ -17,6 +18,7 @@ on:
       - 'main'
     paths:
       - '.github/workflows/Tests.yml'
+      - '.github/check_coverage.jl'
       - 'codecov.yml'
       - 'src/**'
       - 'ext/**'
@@ -75,4 +77,7 @@ jobs:
           file: lcov.info
           name: codecov-umbrella
           fail_ci_if_error: true
+        if: ${{ matrix.version == 'lts' }}
+      - name: Require 100% source line coverage
+        run: julia .github/check_coverage.jl lcov.info
         if: ${{ matrix.version == 'lts' }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
     paths:
       - '.github/workflows/Tests.yml'
+      - 'codecov.yml'
       - 'src/**'
       - 'ext/**'
       - 'test/**'
@@ -16,6 +17,7 @@ on:
       - 'main'
     paths:
       - '.github/workflows/Tests.yml'
+      - 'codecov.yml'
       - 'src/**'
       - 'ext/**'
       - 'test/**'
@@ -72,5 +74,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         if: ${{ matrix.version == 'lts' }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  round: down
+  range: "100...100"
+  status:
+    project:
+      default:
+        target: 100%
+        threshold: 0%
+    patch:
+      default:
+        target: 100%
+        threshold: 0%

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -2,6 +2,7 @@ pages = [
     "Home" => "index.md",
     "API" => "API.md",
     "Symbolic fields" => "typesystem.md",
+    "Type-stability guarantee" => "type_stability.md",
     "Keldysh Conventions" => "conventions.md",
     "Literature" => "literature.md",
     "Examples" => [

--- a/docs/src/type_stability.md
+++ b/docs/src/type_stability.md
@@ -1,0 +1,24 @@
+# Type-stability guarantee
+
+KeldyshContraction.jl continuously enforces type stability for its explicitly supported bosonic computational universe.
+
+The current guarantee covers:
+
+- `Boson` field statistics;
+- exact coefficient storage represented by `ComplexRationals`;
+- floating-point coefficient storage represented by `ComplexF64`;
+- the package-owned pipeline from `InteractionLagrangian` through `DressedPropagator`, `SelfEnergy`, Wigner transformation, and `CollisionIntegral`;
+- package-owned text and LaTeX serialization for objects exercised by that pipeline.
+
+Other `Number` subtypes may work through generic methods, but they are outside this guarantee until they are added to the supported-type contract matrix and CI workload.
+
+The guarantee is enforced by several independent gates:
+
+1. the complete test suite runs with DispatchDoctor in `error` mode;
+2. every supported coefficient domain is exercised through the public computational pipeline with `@inferred`;
+3. resulting stored representations are recursively checked for concrete field types;
+4. JET package analysis must report no package-owned inference/runtime-dispatch errors;
+5. `@unstable` exemptions are forbidden under `src/`;
+6. Codecov project and patch coverage targets are both 100%.
+
+This is an engineering guarantee over the explicitly supported input-type universe. Extending the guarantee to another coefficient/statistics family requires adding that family to the contract workload and making all of the gates above pass.

--- a/test/type_stability_contract.jl
+++ b/test/type_stability_contract.jl
@@ -1,0 +1,64 @@
+using KeldyshContraction, Test
+import KeldyshContraction as KC
+
+function contract_recursively_concrete(@nospecialize(T::Type), seen=Set{Type}())
+    isconcretetype(T) || return false
+    T in seen && return true
+    push!(seen, T)
+    if T <: AbstractArray
+        contract_recursively_concrete(eltype(T), seen) || return false
+    end
+    for FT in fieldtypes(T)
+        contract_recursively_concrete(FT, seen) || return false
+    end
+    return true
+end
+
+@qfields contract_ϕ::Boson
+const contract_c = contract_ϕ[Classical]
+const contract_q = contract_ϕ[Quantum]
+
+function assert_supported_type_contract(coefficient::C, ::Type{D}) where {C<:Real,D<:Number}
+    c = contract_c
+    q = contract_q
+    interaction = -coefficient *
+                  ((c^2 + q^2) * bar(c) * bar(q) + c * q * (bar(c)^2 + bar(q)^2))
+
+    L = @inferred InteractionLagrangian(interaction)
+    G = @inferred DressedPropagator(L, Val(1), Val(3); simplify=false)
+    Σ = @inferred SelfEnergy(G)
+    Gk = @inferred wigner_transform(G)
+    Σk = @inferred wigner_transform(Σ)
+    collision = @inferred KC.CollisionIntegral(Σk)
+
+    @test typeof(G).parameters[1] === D
+    @test typeof(Σ).parameters[1] === D
+    @test typeof(Gk) === typeof(G)
+    @test typeof(Σk) === typeof(Σ)
+    @test collision isa KC.CollisionIntegral{D,0}
+
+    @test contract_recursively_concrete(typeof(L))
+    @test contract_recursively_concrete(typeof(G))
+    @test contract_recursively_concrete(typeof(Σ))
+    @test contract_recursively_concrete(typeof(Gk))
+    @test contract_recursively_concrete(typeof(Σk))
+    @test contract_recursively_concrete(typeof(collision))
+
+    diagram = first(keys(Gk.keldysh.diagrams))
+    io = IOBuffer()
+    @test @inferred(show(io, diagram)) === nothing
+    io = IOBuffer()
+    @test @inferred(show(io, MIME"text/latex"(), diagram)) === nothing
+
+    return nothing
+end
+
+@testset "supported type-stability contract" begin
+    @testset "exact coefficients" begin
+        @test @inferred(assert_supported_type_contract(1 // 2, KC.ComplexRationals)) === nothing
+    end
+
+    @testset "floating-point coefficients" begin
+        @test @inferred(assert_supported_type_contract(0.5, ComplexF64)) === nothing
+    end
+end

--- a/test/type_stability_contract.jl
+++ b/test/type_stability_contract.jl
@@ -21,8 +21,8 @@ const contract_q = contract_ϕ[Quantum]
 function assert_supported_type_contract(coefficient::C, ::Type{D}) where {C<:Real,D<:Number}
     c = contract_c
     q = contract_q
-    interaction = -coefficient *
-                  ((c^2 + q^2) * bar(c) * bar(q) + c * q * (bar(c)^2 + bar(q)^2))
+    interaction =
+        -coefficient * ((c^2 + q^2) * bar(c) * bar(q) + c * q * (bar(c)^2 + bar(q)^2))
 
     L = @inferred InteractionLagrangian(interaction)
     G = @inferred DressedPropagator(L, Val(1), Val(3); simplify=false)
@@ -55,7 +55,8 @@ end
 
 @testset "supported type-stability contract" begin
     @testset "exact coefficients" begin
-        @test @inferred(assert_supported_type_contract(1 // 2, KC.ComplexRationals)) === nothing
+        @test @inferred(assert_supported_type_contract(1 // 2, KC.ComplexRationals)) ===
+            nothing
     end
 
     @testset "floating-point coefficients" begin


### PR DESCRIPTION
Stacked on #252.

This PR turns the completed bosonic type-stability migration into an explicit CI contract.

Contract:
- guarantee bosonic workloads for exact `ComplexRationals` and numerical `ComplexF64` coefficient domains;
- exercise the supported public pipeline end-to-end under DispatchDoctor error mode;
- require inference and recursively concrete stored representations for every guaranteed coefficient domain;
- document that other `Number` subtypes are outside the guarantee until added to the contract matrix;
- make Codecov a required-quality signal and set the repository coverage target to 100%, then close any uncovered package-owned lines exposed by that gate.

This layer changes the guarantee/CI policy, not the physics implementation.