### PR TITLE
ci: certify Julia 1.13 support

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -31,12 +31,18 @@ concurrency:
 
 jobs:
   jet:
-    name: JET - Julia 1.12
+    name: JET - Julia ${{ matrix.version }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       actions: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.12'
+          - '1.13'
     steps:
       - uses: actions/checkout@v7
         with:
@@ -44,7 +50,7 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           show-versioninfo: true
-          version: '1.12'
+          version: ${{ matrix.version }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - name: Set up test environment

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1'
+          - '1.13'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Certify KeldyshContraction on Julia 1.13 while retaining the existing LTS/lower-version coverage.

`Project.toml` already declares `julia = "1.10"`, which includes Julia 1.13 under Pkg compat semantics, so no package compat widening is required.

## Changes

- pin the current-version package test job to Julia 1.13 instead of the moving `1` selector;
- extend the dedicated JET workflow from Julia 1.12 only to a Julia 1.12 + 1.13 matrix;
- retain the existing test-environment JET compatibility, which already includes JET 0.12.

## Validation

On head `fce90b2b9e854827c3dab9781a5db91ee1559700`:

- package Tests: green on LTS and Julia 1.13;
- JET: green on Julia 1.12 and 1.13;
- the Julia 1.13 analyzer resolves JET 0.12.1 and reports `No errors detected`;
- Documentation: green;
- format-check: green;
- Spell Check: green.

No package semantics or analyzer allowlists were changed.