### PR TITLE
ci: restore moving Julia 1 selector

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.13'
+          - '1'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Restore the package-test current-stable lane from explicit Julia `1.13` back to the moving Julia `1` selector.

The previous support PR pinned a lane that already resolved to Julia 1.13. Using `1` preserves current-stable semantics and automatically follows future Julia 1.x releases.

The dedicated JET matrix remains explicitly on Julia 1.12 + 1.13 because that was a genuine additional compatibility check, not a replacement of an existing moving `1` lane.